### PR TITLE
fix: Guard against tweak_name -parameter being None.

### DIFF
--- a/prefixer/cli.py
+++ b/prefixer/cli.py
@@ -59,6 +59,9 @@ def list_tweaks(ctx, param, value):
     ctx.exit()
 
 def print_tweak(ctx, param, tweak_name: str):
+    if not tweak_name or ctx.resilient_parsing:
+        return
+
     all_tweaks: dict[str, TweakData] = get_tweaks()
 
     try:


### PR DESCRIPTION
## Description
Added guard against callback function parameter being None.
Turns out click runs all the option callback functions even if the command line flag for the option is not set, resulting in the callback function running with extra parameters set to None. This resulted into a bug where the 'print_tweak' function gives KeyError when accessing 'all_tweaks[None]' resulting the program exiting with error, even when the user did not use the 'print-tweak' functionality.

Not sure if this is intended behaviour or misconfiguration in the '--print-tweak' option. The same guard pattern is found in click-examples in multiple places, so maybe it is how it is designed to work?

## Type of Change
<!-- Check one -->
- [ ] `feat:` New feature
- [x] `fix:` Bug fix
- [ ] `docs:` Documentation update
- [ ] `tweak:` New tweak file
- [ ] `test:` Test additions/changes
- [ ] `chore:` Build/tooling changes

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Code follows project style (type hints, dataclasses)
- [ ] Added tests for new functionality (if applicable)
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
